### PR TITLE
feat: Create Release 워크플로우 및 Docker 빌드 구성

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version bump type'
+        required: false
+        default: 'minor'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    uses: kenshin579/actions/.github/workflows/release.yml@main
+    with:
+      version_type: ${{ inputs.version_type }}
+    secrets: inherit
+
+  docker-backend:
+    needs: release
+    if: ${{ always() && needs.release.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: docker.io/kenshin579/ai-chatbot-be
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release.outputs.new_version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.new_version }}
+            type=raw,value=latest
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  docker-frontend:
+    needs: release
+    if: ${{ always() && needs.release.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: docker.io/kenshin579/ai-chatbot-fe
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release.outputs.new_version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.new_version }}
+            type=raw,value=latest
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,87 @@
-.PHONY: dev test index build lint clean
+.PHONY: help run-fe run-be run-all test index lint build install clean tag docker-push
 
-# Backend
-dev:
-	cd backend && uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8080
+# ========================================
+# 도움말
+# ========================================
+
+help:
+	@echo "AI Chatbot 개발 명령어"
+	@echo ""
+	@echo "개발 서버:"
+	@echo "  run-fe        Frontend 실행 (Next.js, 포트 3000)"
+	@echo "  run-be        Backend 실행 (FastAPI, 포트 8080)"
+	@echo "  run-all       Frontend + Backend 동시 실행"
+	@echo ""
+	@echo "개발 도구:"
+	@echo "  test           테스트 실행"
+	@echo "  lint           린트 검사"
+	@echo "  index          blog-v2 문서 인덱싱"
+	@echo "  index-invest   투자 블로그 문서 인덱싱"
+	@echo "  install        의존성 설치"
+	@echo ""
+	@echo "릴리스:"
+	@echo "  make tag patch|minor|major   버전 태그 생성"
+	@echo "  make docker-push fe|be|all   Docker 이미지 푸시"
+
+# ========================================
+# 개발 서버 실행
+# ========================================
+
+run-fe:
+	@cd frontend && npm run dev
+
+run-be:
+	@cd backend && uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8080
+
+run-all:
+	@cd backend && uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8080 & cd frontend && npm run dev
+
+# ========================================
+# 개발 도구
+# ========================================
 
 test:
-	cd backend && uv run pytest -v
-
-index:
-	cd backend && uv run python scripts/index_documents.py --blog-id blog-v2 --contents-dir ../../blog-v2.advenoh.pe.kr/contents/
-
-index-investment:
-	cd backend && uv run python scripts/index_documents.py --blog-id investment --contents-dir ../../investment.advenoh.pe.kr/contents/
+	@cd backend && uv run pytest -v
 
 lint:
-	cd backend && uv run ruff check .
+	@cd backend && uv run ruff check .
+
+index:
+	@cd backend && uv run python scripts/index_documents.py --blog-id blog-v2 --contents-dir ../../blog-v2.advenoh.pe.kr/contents/
+
+index-invest:
+	@cd backend && uv run python scripts/index_documents.py --blog-id investment --contents-dir ../../investment.advenoh.pe.kr/contents/
 
 build:
-	cd backend && docker build -t kenshin579/rag-chatbot:latest .
+	@cd backend && docker build -t kenshin579/ai-chatbot-be:latest .
 
-# Setup
 install:
-	cd backend && uv sync
+	@cd backend && uv sync
 
 install-dev:
-	cd backend && uv sync --extra dev
+	@cd backend && uv sync --extra dev
 
 install-eval:
-	cd backend && uv sync --extra eval
+	@cd backend && uv sync --extra eval
 
 clean:
-	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
-	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
+	@find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	@find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
+
+# ========================================
+# 릴리스 및 배포
+# ========================================
+
+# 태그 및 릴리스 (인자: patch, minor, major)
+# 사용법: make tag patch / make tag minor / make tag major
+tag:
+	@./scripts/release.sh $(filter-out $@,$(MAKECMDGOALS))
+
+# Docker 빌드 및 푸시 (인자: fe, be, all)
+# 사용법: make docker-push fe / make docker-push be / make docker-push all
+docker-push:
+	@./scripts/docker-push.sh $(filter-out $@,$(MAKECMDGOALS))
+
+# 인자를 타겟으로 인식하지 않도록 처리
+%:
+	@:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,48 @@
+# Stage 1: Dependencies
+FROM node:20-alpine AS deps
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci --prefer-offline --no-audit
+
+# Stage 2: Build Stage
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG NEXT_PUBLIC_API_URL=https://ai-chatbot.advenoh.pe.kr
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build
+
+# Stage 3: Production Stage
+FROM node:20-alpine AS runner
+
+RUN apk add --no-cache dumb-init
+
+WORKDIR /app
+
+RUN addgroup -g 1001 -S nodejs && \
+    adduser -S nextjs -u 1001
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME="0.0.0.0"
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["node", "server.js"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/scripts/docker-push.sh
+++ b/scripts/docker-push.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+TARGET=${1:-all}
+VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+VERSION_NUM=${VERSION#v}
+MAJOR_MINOR=$(echo $VERSION_NUM | cut -d. -f1,2)
+
+REGISTRY=${DOCKER_REGISTRY:-docker.io}
+USERNAME=${DOCKER_USERNAME:-kenshin579}
+
+build_and_push() {
+  local name=$1
+  local context=$2
+  local build_args=${3:-}
+  local image="${REGISTRY}/${USERNAME}/${name}"
+
+  echo "Building and pushing ${image}..."
+
+  docker buildx build \
+    --platform linux/arm64 \
+    ${build_args} \
+    --tag "${image}:${VERSION_NUM}" \
+    --tag "${image}:${MAJOR_MINOR}" \
+    --tag "${image}:latest" \
+    --push \
+    "${context}"
+
+  echo "Successfully pushed ${image}"
+}
+
+case $TARGET in
+  fe)  build_and_push "ai-chatbot-fe" "./frontend" ;;
+  be)  build_and_push "ai-chatbot-be" "./backend" ;;
+  all)
+    build_and_push "ai-chatbot-be" "./backend"
+    build_and_push "ai-chatbot-fe" "./frontend"
+    ;;
+  *) echo "Usage: $0 [fe|be|all]"; exit 1 ;;
+esac

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+VERSION_TYPE=${1:-minor}
+
+# 최신 태그 가져오기
+git fetch --tags
+LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+CURRENT_VERSION=${LATEST_TAG#v}
+
+# 버전 파싱
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+# 버전 범프
+case $VERSION_TYPE in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+  *) echo "Usage: $0 [patch|minor|major]"; exit 1 ;;
+esac
+
+NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+
+echo "Current version: $LATEST_TAG"
+echo "New version: $NEW_VERSION"
+
+# Git 태그 생성 및 푸시
+git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
+git push origin "$NEW_VERSION"
+
+# GitHub 릴리스 생성
+gh release create "$NEW_VERSION" \
+  --title "$NEW_VERSION" \
+  --generate-notes
+
+echo "Released: $NEW_VERSION"


### PR DESCRIPTION
## Summary
- Create Release GitHub Actions 워크플로우 추가 (release + docker-backend + docker-frontend 병렬 빌드)
- frontend Dockerfile 추가 (Next.js standalone multi-stage)
- 로컬 릴리스/도커 스크립트 추가 (scripts/release.sh, docker-push.sh)
- Makefile을 inspireme 패턴으로 정리 (help, run-fe/be/all, tag, docker-push)
- Docker 이미지명 ai-chatbot-be / ai-chatbot-fe로 통일

## Test plan
- [ ] GitHub Actions에서 Create Release 워크플로우 실행 확인
- [ ] Docker 이미지 빌드 정상 동작 확인
- [ ] make help 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)