### PR TITLE
fix: ChromaDB tags 메타데이터 타입 검증 오류 수정

### DIFF
--- a/backend/app/rag/document_loader.py
+++ b/backend/app/rag/document_loader.py
@@ -72,9 +72,9 @@ def load_blog_documents(contents_dir: str, blog_id: str) -> list[Document]:
             "source": relative_path,
             "url": build_post_url(relative_path, blog_id),
         }
-        # tags가 비어있지 않은 경우에만 추가
+        # tags가 비어있지 않은 경우에만 추가 (모두 문자열로 변환)
         if tags:
-            doc_metadata["tags"] = tags
+            doc_metadata["tags"] = [str(tag) for tag in tags]
 
         documents.append(Document(page_content=body, metadata=doc_metadata))
 


### PR DESCRIPTION
## Summary
- investment 블로그 인덱싱 시 ChromaDB tags 메타데이터 타입 검증 오류 수정
- tags 배열에 숫자와 문자열이 혼재되어 발생한 문제 해결

## Changes
- `backend/app/rag/document_loader.py`: tags 배열의 모든 요소를 문자열로 변환 (`[str(tag) for tag in tags]`)

## Test plan
- [x] investment 블로그 인덱싱 성공 (95개 문서, 547개 청크)
- [x] ChromaDB Collection 생성 확인

## Background
ChromaDB는 메타데이터 리스트 값이 모두 동일한 타입이어야 한다는 제약이 있습니다. investment 블로그의 일부 문서에서 tags에 숫자(예: 319640)가 포함되어 인덱싱 실패했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)