### PR TITLE
[#14] fix: async_session_factory 임포트 바인딩 버그 수정

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -15,7 +15,8 @@ from app.api.models import (
     Source,
 )
 from app.config import Settings, get_settings
-from app.db.connection import async_session_factory, get_session
+import app.db.connection as db_conn
+from app.db.connection import get_session
 from app.db.repository import QueryLogRepository
 from app.rag.chain import create_rag_chain
 from app.rag.chunker import split_documents
@@ -93,9 +94,9 @@ async def chat(
     response_time_ms = int((time.time() - start_time) * 1000)
 
     # 쿼리 로그 저장
-    if async_session_factory:
+    if db_conn.async_session_factory:
         try:
-            async with async_session_factory() as session:
+            async with db_conn.async_session_factory() as session:
                 repo = QueryLogRepository(session)
                 await repo.save_query_log(
                     message_id=message_id,

--- a/docs/start/8_chatbot_monitoring_todo.md
+++ b/docs/start/8_chatbot_monitoring_todo.md
@@ -65,7 +65,7 @@ SELECT user, host FROM mysql.user WHERE user = 'ai_chatbot';
 
 ### 테스트
 - [x] 로컬 MySQL + Liquibase로 스키마 생성 확인
-- [ ] /chat 호출 → query_logs 테이블 기록 확인
+- [x] /chat 호출 → query_logs 테이블 기록 확인
 - [x] Docker 이미지 빌드 → PreSync Job 실행 → 테이블 생성 확인
 
 ---


### PR DESCRIPTION
## Summary

- `routes.py`에서 `async_session_factory`를 직접 임포트하면 모듈 로드 시점의 `None` 값이 고정되는 Python 임포트 바인딩 버그 수정
- `import app.db.connection as db_conn` 모듈 임포트로 변경하여 `init_db()` 이후에도 동적으로 최신 값 참조
- `/chat` 호출 → `query_logs` 테이블 정상 기록 확인 완료
- todo M1 테스트 항목 완료 체크

## Root Cause

```python
# 버그: 임포트 시점의 None이 고정됨
from app.db.connection import async_session_factory  # None

# 수정: 모듈 참조로 변경
import app.db.connection as db_conn
# db_conn.async_session_factory → 항상 최신 값 참조
```

## Test plan

- [x] `/chat` API 호출 → 200 OK 응답 확인
- [x] `query_logs` 테이블에 `message_id`, 질문, 응답시간, `has_results` 정상 저장 확인
- [x] `kenshin579/ai-chatbot-be:0.5.2` 이미지 K8s 배포 후 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)