### PR TITLE
[#11] feat: M2 - POST /feedback 엔드포인트 구현 및 LangSmith 연동

### DIFF
--- a/backend/app/api/models.py
+++ b/backend/app/api/models.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel
 
 
@@ -30,4 +32,15 @@ class IndexResponse(BaseModel):
 
 
 class HealthResponse(BaseModel):
+    status: str
+
+
+class FeedbackRequest(BaseModel):
+    message_id: str
+    blog_id: str
+    question: str
+    rating: Literal["up", "down"]
+
+
+class FeedbackResponse(BaseModel):
     status: str

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -29,6 +29,9 @@ class Settings(BaseSettings):
     # Index API auth
     rag_index_token: str = ""
 
+    # LangSmith
+    langsmith_api_key: str = ""
+
     # MySQL
     mysql_host: str = "localhost"
     mysql_port: int = 3306

--- a/docs/start/8_chatbot_monitoring_todo.md
+++ b/docs/start/8_chatbot_monitoring_todo.md
@@ -73,17 +73,17 @@ SELECT user, host FROM mysql.user WHERE user = 'ai_chatbot';
 ## M2: 사용자 피드백 API + LangSmith 연동
 
 ### Backend - /feedback API
-- [ ] `app/api/models.py` - FeedbackRequest 모델 추가
-- [ ] `app/api/routes.py` - POST /feedback 엔드포인트 구현
-- [ ] `app/db/repository.py` - save_feedback 메서드 추가
-- [ ] LangSmith Feedback API 연동 (langsmith Client.create_feedback)
+- [x] `app/api/models.py` - FeedbackRequest 모델 추가
+- [x] `app/api/routes.py` - POST /feedback 엔드포인트 구현
+- [x] `app/db/repository.py` - save_feedback 메서드 추가
+- [x] LangSmith Feedback API 연동 (langsmith Client.create_feedback) - LANGSMITH_API_KEY 설정 시 활성화
 
 ### Charts - Gateway 라우트
 - [x] `charts/gateway/values.yaml` - `/feedback` 라우트 추가 (→ ai-chatbot-be-service)
 
 ### 테스트
-- [ ] POST /feedback API 호출 → feedbacks 테이블 저장 확인
-- [ ] LangSmith 대시보드에서 피드백 데이터 확인
+- [x] POST /feedback API 호출 → feedbacks 테이블 저장 확인
+- [ ] LangSmith 대시보드에서 피드백 데이터 확인 (LANGSMITH_API_KEY 설정 후 확인 필요)
 
 ---
 


### PR DESCRIPTION
## Summary

- `FeedbackRequest` / `FeedbackResponse` 모델 추가 (`rating: "up" | "down"`)
- `POST /feedback` 엔드포인트 구현 - `feedbacks` 테이블 저장
- LangSmith `Client.create_feedback` 연동 (`LANGSMITH_API_KEY` 설정 시 자동 활성화)
- `config.py`에 `langsmith_api_key` 설정 추가

## Test plan

- [x] `POST /feedback` 호출 → `feedbacks` 테이블 저장 확인
- [x] `LANGSMITH_API_KEY` 설정 후 에러 없이 200 OK 응답 확인
- [ ] LangSmith 대시보드에서 피드백 데이터 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)