### PR TITLE
docs: InspireMe 챗봇 PRD 및 구현 문서 작성

### DIFF
--- a/docs/start/3_inspire_bot_implementation.md
+++ b/docs/start/3_inspire_bot_implementation.md
@@ -1,0 +1,512 @@
+# InspireMe 챗봇 - 구현 계획서
+
+## 1. 프로젝트 구조 변경
+
+### 1.1 ai-chatbot Backend 신규/수정 파일
+
+```
+backend/
+├── app/
+│   ├── api/
+│   │   └── routes.py              # /index/{blog_id} 분기 추가 (inspireme)
+│   ├── config.py                  # inspireme DB 설정 + blog_collections 추가
+│   ├── prompts/
+│   │   └── templates.py           # INSPIREME_SYSTEM_PROMPT 추가
+│   └── rag/
+│       ├── chain.py               # blog_id별 프롬프트 분기
+│       └── inspireme_loader.py    # 신규: MySQL DB → Document 변환
+├── scripts/
+│   └── index_documents.py         # --blog-id inspireme 지원 추가
+└── pyproject.toml                 # aiomysql 의존성 (이미 존재)
+```
+
+### 1.2 inspireme Frontend 신규/수정 파일
+
+```
+inspireme.advenoh.pe.kr/frontend/
+├── components/
+│   └── chatbot/                       # 신규 디렉토리
+│       ├── ChatbotButton.tsx          # 플로팅 버튼
+│       ├── ChatbotPanel.tsx           # 챗봇 패널 (메인 컨테이너)
+│       ├── ChatMessageList.tsx        # 메시지 목록 + 피드백 버튼
+│       └── ChatInput.tsx              # 입력 폼
+├── lib/
+│   └── chatbot-api.ts                 # 신규: ai-chatbot API 클라이언트
+├── app/
+│   └── layout.tsx                     # ChatbotButton 추가
+└── next.config.ts                     # /api/chatbot/* 리라이트 추가
+```
+
+### 1.3 Charts 수정 파일
+
+```
+charts/charts/
+├── ai-chatbot-be/
+│   ├── values.yaml                    # inspireme MySQL 환경변수 추가
+│   └── templates/configmap.yaml       # INSPIREME_MYSQL_* 환경변수 추가
+└── gateway/values.yaml                # inspireme → ai-chatbot CORS 또는 라우트
+```
+
+---
+
+## 2. ai-chatbot Backend 구현
+
+### 2.1 설정 추가 (`app/config.py`)
+
+```python
+class Settings(BaseSettings):
+    # 기존 설정...
+
+    # 멀티 블로그 Collection 설정 — inspireme 추가
+    blog_collections: dict[str, str] = {
+        "blog-v2": "IT 블로그",
+        "investment": "투자 블로그",
+        "inspireme": "명언",
+    }
+
+    # inspireme DB 접속 정보 (인덱싱 시 사용)
+    inspireme_mysql_host: str = "localhost"
+    inspireme_mysql_port: int = 3306
+    inspireme_mysql_database: str = "inspireme"
+    inspireme_mysql_user: str = "inspireme"
+    inspireme_mysql_password: str = ""
+
+    @property
+    def inspireme_database_url(self) -> str:
+        return (
+            f"mysql+aiomysql://{self.inspireme_mysql_user}:{quote_plus(self.inspireme_mysql_password)}"
+            f"@{self.inspireme_mysql_host}:{self.inspireme_mysql_port}/{self.inspireme_mysql_database}"
+        )
+```
+
+### 2.2 Document Loader 신규 (`app/rag/inspireme_loader.py`)
+
+```python
+import logging
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from langchain_core.documents import Document
+
+logger = logging.getLogger(__name__)
+
+QUOTES_QUERY = """
+SELECT q.id, q.author, q.author_id, q.topics, q.tags,
+       a.slug AS author_slug, a.birth_year, a.death_year, a.nationality,
+       qt_ko.content AS content_ko, qt_en.content AS content_en,
+       at_ko.name AS author_name_ko, at_en.name AS author_name_en,
+       at_ko.bio AS author_bio_ko
+FROM quotes q
+LEFT JOIN authors a ON q.author_id = a.id
+LEFT JOIN quote_translations qt_ko ON q.id = qt_ko.quote_id AND qt_ko.lang = 'ko'
+LEFT JOIN quote_translations qt_en ON q.id = qt_en.quote_id AND qt_en.lang = 'en'
+LEFT JOIN author_translations at_ko ON a.id = at_ko.author_id AND at_ko.lang = 'ko'
+LEFT JOIN author_translations at_en ON a.id = at_en.author_id AND at_en.lang = 'en'
+"""
+
+AUTHORS_QUERY = """
+SELECT a.id, a.slug, a.birth_year, a.death_year, a.nationality,
+       at_ko.name AS name_ko, at_ko.bio AS bio_ko,
+       at_en.name AS name_en, at_en.bio AS bio_en
+FROM authors a
+LEFT JOIN author_translations at_ko ON a.id = at_ko.author_id AND at_ko.lang = 'ko'
+LEFT JOIN author_translations at_en ON a.id = at_en.author_id AND at_en.lang = 'en'
+"""
+
+BASE_URL = "https://inspireme.advenoh.pe.kr"
+
+
+def _build_quote_document(row: dict) -> Document:
+    """명언 DB 레코드를 LangChain Document로 변환한다."""
+    content_parts = []
+    if row.get("content_ko"):
+        content_parts.append(f'"{row["content_ko"]}"')
+    if row.get("content_en"):
+        content_parts.append(f'"{row["content_en"]}"')
+
+    author_name = row.get("author_name_ko") or row.get("author") or "Unknown"
+    author_name_en = row.get("author_name_en") or ""
+    if author_name_en:
+        content_parts.append(f"— {author_name} ({author_name_en})")
+    else:
+        content_parts.append(f"— {author_name}")
+
+    topics = row.get("topics") or []
+    tags = row.get("tags") or []
+    if topics:
+        content_parts.append(f"주제: {', '.join(topics)}")
+    if tags:
+        content_parts.append(f"태그: {', '.join(tags)}")
+    if row.get("author_bio_ko"):
+        content_parts.append(f"저자 소개: {row['author_bio_ko']}")
+
+    page_content = "\n".join(content_parts)
+
+    metadata = {
+        "blog_id": "inspireme",
+        "type": "quote",
+        "quote_id": row["id"],
+        "author": author_name,
+        "url": f"{BASE_URL}/quotes/{row['id']}",
+    }
+    if row.get("author_slug"):
+        metadata["author_slug"] = row["author_slug"]
+    if topics:
+        metadata["topics"] = topics
+    if tags:
+        metadata["tags"] = tags
+
+    return Document(page_content=page_content, metadata=metadata)
+
+
+def _build_author_document(row: dict) -> Document:
+    """저자 DB 레코드를 LangChain Document로 변환한다."""
+    name_ko = row.get("name_ko") or "Unknown"
+    name_en = row.get("name_en") or ""
+
+    content_parts = []
+    if name_en:
+        content_parts.append(f"{name_ko} ({name_en})")
+    else:
+        content_parts.append(name_ko)
+
+    if row.get("nationality"):
+        content_parts.append(f"국적: {row['nationality']}")
+    if row.get("birth_year"):
+        birth = f"출생: {row['birth_year']}"
+        if row.get("death_year"):
+            birth += f", 사망: {row['death_year']}"
+        content_parts.append(birth)
+    if row.get("bio_ko"):
+        content_parts.append(f"소개: {row['bio_ko']}")
+    if row.get("bio_en"):
+        content_parts.append(f"Bio: {row['bio_en']}")
+
+    page_content = "\n".join(content_parts)
+
+    metadata = {
+        "blog_id": "inspireme",
+        "type": "author",
+        "author_id": row["id"],
+        "author_slug": row.get("slug", ""),
+        "url": f"{BASE_URL}/authors/{row.get('slug', '')}",
+    }
+
+    return Document(page_content=page_content, metadata=metadata)
+
+
+async def load_inspireme_documents(database_url: str) -> list[Document]:
+    """inspireme MySQL DB에서 명언/저자 데이터를 로드하여 Document 리스트로 반환한다."""
+    engine = create_async_engine(database_url, pool_pre_ping=True)
+
+    documents = []
+    try:
+        async with engine.connect() as conn:
+            # 명언 로드
+            result = await conn.execute(text(QUOTES_QUERY))
+            rows = result.mappings().all()
+            for row in rows:
+                documents.append(_build_quote_document(dict(row)))
+            logger.info(f"명언 {len(rows)}개 로드 완료")
+
+            # 저자 로드
+            result = await conn.execute(text(AUTHORS_QUERY))
+            rows = result.mappings().all()
+            for row in rows:
+                documents.append(_build_author_document(dict(row)))
+            logger.info(f"저자 {len(rows)}명 로드 완료")
+    finally:
+        await engine.dispose()
+
+    logger.info(f"총 {len(documents)}개 Document 생성")
+    return documents
+```
+
+### 2.3 인덱싱 엔드포인트 수정 (`app/api/routes.py`)
+
+기존 `reindex` 함수의 contents_dirs 분기 로직에 inspireme 처리를 추가한다.
+
+```python
+from app.rag.inspireme_loader import load_inspireme_documents
+
+@router.post("/index/{blog_id}", response_model=IndexResponse)
+async def reindex(
+    blog_id: str,
+    _token: str = Depends(verify_index_token),
+    settings: Settings = Depends(get_settings),
+    manager: VectorStoreManager = Depends(get_vector_store_manager),
+):
+    if blog_id not in settings.blog_collections:
+        raise HTTPException(status_code=400, detail=f"Unknown blog_id: {blog_id}")
+
+    manager.delete_collection(blog_id)
+
+    if blog_id == "inspireme":
+        # DB에서 직접 로드 (청킹 불필요)
+        documents = await load_inspireme_documents(settings.inspireme_database_url)
+        indexed = manager.index_documents(blog_id, documents)
+    else:
+        # 기존: Markdown 파일 로드 + 청킹
+        contents_dirs = {
+            "blog-v2": "../../blog-v2.advenoh.pe.kr/contents/",
+            "investment": "../../investment.advenoh.pe.kr/contents/",
+        }
+        contents_dir = contents_dirs.get(blog_id)
+        if not contents_dir:
+            raise HTTPException(status_code=400, detail=f"No contents directory for: {blog_id}")
+        documents = load_blog_documents(contents_dir, blog_id)
+        chunks = split_documents(documents, settings.chunk_size, settings.chunk_overlap)
+        indexed = manager.index_documents(blog_id, chunks)
+
+    return IndexResponse(status="ok", blog_id=blog_id, indexed_chunks=indexed)
+```
+
+### 2.4 inspireme 전용 프롬프트 (`app/prompts/templates.py`)
+
+```python
+# 기존 SYSTEM_PROMPT 아래에 추가
+
+INSPIREME_SYSTEM_PROMPT = """당신은 명언 추천 전문 AI 어시스턴트입니다.
+사용자의 질문에 맞는 명언을 추천하고, 저자 정보를 안내합니다.
+
+## 답변 스타일
+
+- **공감과 추천**: 사용자의 감정이나 상황에 공감하며 적절한 명언을 추천하세요.
+- **원문 인용**: 명언을 인용할 때는 검색된 원문을 그대로 사용하세요.
+- **출처 명시**: 저자 이름을 반드시 함께 제공하세요.
+
+## 답변 규칙
+
+1. **근거 기반**: 반드시 컨텍스트에 포함된 명언만 추천하세요. 검색 결과에 없는 명언을 지어내지 마세요.
+2. **정보 없음 처리**: 관련 명언을 찾지 못한 경우 "관련 명언을 찾지 못했습니다."라고 답변하세요.
+3. **다국어**: 한국어로 답변하되, 영어 원문이 있으면 함께 제공하세요.
+4. **간결함**: 핵심을 중심으로 간결하게 답변하세요.
+
+## 컨텍스트
+
+{context}"""
+```
+
+### 2.5 체인 프롬프트 분기 (`app/rag/chain.py`)
+
+```python
+from app.prompts.templates import SYSTEM_PROMPT, INSPIREME_SYSTEM_PROMPT
+
+def create_rag_chain(
+    vector_store: Chroma,
+    model: str,
+    top_k: int = 5,
+    retriever: RetrieverLike | None = None,
+    blog_id: str | None = None,         # 신규 파라미터
+):
+    llm = ChatOpenAI(model=model, temperature=0)
+
+    if retriever is None:
+        retriever = vector_store.as_retriever(search_kwargs={"k": top_k})
+
+    # 대화 히스토리를 고려한 질문 재작성 체인 (기존 동일)
+    contextualize_prompt = ChatPromptTemplate.from_messages([
+        ("system", "대화 히스토리와 최신 사용자 질문을 고려하여, "
+         "대화 히스토리 없이도 이해할 수 있는 독립적인 질문으로 재작성하세요. "
+         "질문을 답변하지 마세요. 재작성이 필요 없으면 그대로 반환하세요."),
+        MessagesPlaceholder("chat_history"),
+        ("human", "{input}"),
+    ])
+    history_aware_retriever = create_history_aware_retriever(
+        llm, retriever, contextualize_prompt
+    )
+
+    # blog_id에 따라 프롬프트 분기
+    system_prompt = INSPIREME_SYSTEM_PROMPT if blog_id == "inspireme" else SYSTEM_PROMPT
+
+    qa_prompt = ChatPromptTemplate.from_messages([
+        ("system", system_prompt),
+        MessagesPlaceholder("chat_history"),
+        ("human", "{input}"),
+    ])
+    question_answer_chain = create_stuff_documents_chain(llm, qa_prompt)
+
+    return create_retrieval_chain(history_aware_retriever, question_answer_chain)
+```
+
+### 2.6 routes.py 호출부 수정
+
+```python
+# /chat 엔드포인트에서 blog_id를 create_rag_chain에 전달
+chain = create_rag_chain(store, settings.openai_model, settings.top_k, blog_id=request.blog_id)
+```
+
+---
+
+## 3. inspireme Frontend 구현
+
+### 3.1 Next.js 리라이트 추가 (`next.config.ts`)
+
+```typescript
+async rewrites() {
+    const backendUrl = process.env.BACKEND_URL || "http://localhost:8080";
+    const chatbotUrl = process.env.CHATBOT_API_URL || "http://localhost:8080";
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${backendUrl}/api/:path*`,
+      },
+      {
+        source: "/chatbot-api/:path*",
+        destination: `${chatbotUrl}/:path*`,
+      },
+    ];
+},
+```
+
+### 3.2 API 클라이언트 (`lib/chatbot-api.ts`)
+
+```typescript
+export interface ChatMessage {
+  role: "human" | "ai";
+  content: string;
+}
+
+export interface Source {
+  title: string;
+  url: string;
+}
+
+export interface ChatResponse {
+  answer: string;
+  sources: Source[];
+  message_id: string;
+}
+
+export interface FeedbackRequest {
+  message_id: string;
+  blog_id: string;
+  question: string;
+  rating: "up" | "down";
+}
+
+const BASE_URL = "/chatbot-api";
+
+export async function sendChat(
+  question: string,
+  chatHistory: ChatMessage[] = [],
+): Promise<ChatResponse> {
+  const res = await fetch(`${BASE_URL}/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      blog_id: "inspireme",
+      question,
+      chat_history: chatHistory,
+    }),
+  });
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({}));
+    throw new Error(error.detail || `HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function sendFeedback(request: FeedbackRequest): Promise<void> {
+  await fetch(`${BASE_URL}/feedback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+}
+```
+
+### 3.3 ChatbotButton (`components/chatbot/ChatbotButton.tsx`)
+
+- 우측 하단 고정 위치 (`fixed bottom-6 right-6`)
+- `MessageCircle` 아이콘 (lucide-react)
+- 클릭 시 ChatbotPanel 토글
+- z-index: 50
+
+### 3.4 ChatbotPanel (`components/chatbot/ChatbotPanel.tsx`)
+
+- 우측 하단 400×500px 패널 (`fixed bottom-20 right-6`)
+- 헤더: "명언 AI 도우미" + 닫기 버튼 (X)
+- 메시지 상태 관리 (messages, isLoading, error)
+- chat_history 구성하여 sendChat 호출
+- ChatMessageList + ChatInput 합성
+
+### 3.5 ChatMessageList (`components/chatbot/ChatMessageList.tsx`)
+
+- ScrollArea로 감싸고 자동 스크롤
+- 사용자 메시지: 우측 파란색 (`bg-primary text-primary-foreground`)
+- AI 메시지: 좌측 회색 (`bg-muted`)
+- 출처 링크: `/quotes/{id}`로 이동
+- 👍👎 피드백 버튼 (sendFeedback 호출)
+- 로딩 상태: "답변을 생성하고 있습니다..." 펄스 애니메이션
+- 초기 상태: 추천 질문 예시 표시
+
+### 3.6 ChatInput (`components/chatbot/ChatInput.tsx`)
+
+- Input + Send 버튼
+- 엔터 키 제출
+- 로딩 중 비활성화
+- placeholder: "명언에 대해 질문해 보세요..."
+
+### 3.7 Root Layout에 ChatbotButton 추가
+
+```typescript
+// app/layout.tsx
+import { ChatbotButton } from "@/components/chatbot/ChatbotButton";
+
+// layout return 부분에 추가
+<ChatbotButton />
+```
+
+---
+
+## 4. Charts 변경
+
+### 4.1 ai-chatbot-be 환경변수 추가 (`charts/ai-chatbot-be/values.yaml`)
+
+```yaml
+config:
+  # 기존 설정...
+  inspiremeMysqlHost: "mysql-headless.app.svc.cluster.local"
+  inspiremeMysqlPort: "3306"
+  inspiremeMysqlDatabase: "inspireme"
+
+secrets:
+  # 기존 설정...
+  inspiremeMysql:
+    user: "inspireme"
+    password: "<비밀번호>"
+```
+
+### 4.2 ConfigMap 환경변수 추가 (`charts/ai-chatbot-be/templates/configmap.yaml`)
+
+- `INSPIREME_MYSQL_HOST`, `INSPIREME_MYSQL_PORT`, `INSPIREME_MYSQL_DATABASE`
+
+### 4.3 Secret 환경변수 추가 (`charts/ai-chatbot-be/templates/secret.yaml`)
+
+- `INSPIREME_MYSQL_USER`, `INSPIREME_MYSQL_PASSWORD`
+
+### 4.4 inspireme-fe 환경변수 추가 (`charts/inspireme-fe/values.yaml`)
+
+```yaml
+config:
+  chatbotApiUrl: "http://ai-chatbot-be-service:80"
+```
+
+---
+
+## 5. 테스트
+
+### 5.1 Backend 단위 테스트
+
+- `test_inspireme_loader.py`: _build_quote_document, _build_author_document 변환 정확성
+- `test_inspireme_loader.py`: 다국어 번역 포함 여부 + 빈 번역 fallback
+- `test_api.py`: POST /index/inspireme 정상 동작
+- `test_api.py`: POST /chat { blog_id: "inspireme" } 정상 응답
+
+### 5.2 E2E 테스트 (MCP Playwright)
+
+- inspireme 사이트에서 플로팅 버튼 표시 확인
+- 버튼 클릭 → 챗봇 패널 열림 확인
+- 질문 입력 → 답변 표시 확인
+- 출처 링크 클릭 → 명언 상세 페이지 이동 확인
+- 👍👎 피드백 버튼 클릭 확인

--- a/docs/start/3_inspire_bot_prd.md
+++ b/docs/start/3_inspire_bot_prd.md
@@ -1,0 +1,433 @@
+# InspireMe 챗봇 - 프로젝트 PRD
+
+## 1. 개요
+
+### 1.1 목적
+
+`inspireme.advenoh.pe.kr` 사이트에 AI 챗봇을 추가하여 사용자가 명언 추천/검색, 저자 정보 조회를 자연어로 할 수 있도록 한다. 기존 `ai-chatbot.advenoh.pe.kr` 백엔드의 RAG 파이프라인에 inspireme 데이터 소스를 추가하고, inspireme 프론트엔드에 챗봇 UI를 임베드한다.
+
+### 1.2 선행 조건
+
+- `ai-chatbot.advenoh.pe.kr` API 서버 배포 완료 (`6_chatbot_project_prd.md`)
+- `inspireme.advenoh.pe.kr` 백엔드/프론트엔드 배포 완료
+- ChromaDB 서버 운영 중
+- MySQL에 inspireme DB (quotes, authors 테이블) 데이터 존재
+
+### 1.3 관련 Repo
+
+- **ai-chatbot**: [ai-chatbot.advenoh.pe.kr](https://github.com/kenshin579/ai-chatbot.advenoh.pe.kr) — Backend (FastAPI), Frontend (Next.js)
+- **inspireme**: [inspireme.advenoh.pe.kr](https://github.com/kenshin579/inspireme.advenoh.pe.kr) — Backend (Go/Echo), Frontend (Next.js)
+
+---
+
+## 2. 핵심 도전과제
+
+기존 ai-chatbot의 RAG 파이프라인은 **마크다운 파일** 기반이다. inspireme 데이터를 지원하려면 다음 차이점을 해결해야 한다.
+
+| 항목 | 기존 (blog-v2) | inspireme |
+|------|---------------|-----------|
+| 데이터 소스 | Markdown 파일 (`contents/index.md`) | MySQL DB (quotes, authors 테이블) |
+| 문서 크기 | 블로그 글 (수백~수천 자) | 명언 1-2문장 (10~100자) |
+| 청킹 전략 | `chunk_size=1000`, Markdown 구분자 기반 | 청킹 불필요 (명언 1개 = 1 Document) |
+| 메타데이터 | frontmatter (title, date, category, tags) | author, topics, tags, language |
+| 다국어 | 단일 언어 콘텐츠 | ko/en 번역 테이블 (quote_translations, author_translations) |
+| 인덱싱 트리거 | GitHub Actions (contents/ 변경 시) | API 호출 또는 스케줄 (DB 변경 시) |
+| URL 연결 | 블로그 포스트 URL | inspireme 명언 상세 페이지 URL |
+
+---
+
+## 3. 핵심 기능
+
+1. **DB → Document 변환**: MySQL의 명언/저자 데이터를 LangChain Document로 변환하여 ChromaDB에 인덱싱
+2. **명언 특화 RAG**: 짧은 텍스트에 최적화된 검색/답변 전략
+3. **inspireme 프론트엔드 챗봇 UI**: 기존 사이트에 채팅 위젯 통합
+
+---
+
+## 4. 데이터 소스 전략 (DB → Document 변환)
+
+### 4.1 변환 방식
+
+MySQL DB에서 명언과 저자 데이터를 읽어 LangChain `Document` 객체로 변환한다. 명언은 1-2문장으로 짧기 때문에 **청킹 없이 1 명언 = 1 Document**로 처리한다.
+
+#### Document 구조 — 명언
+
+```python
+Document(
+    page_content="""
+"{content_ko}"
+"{content_en}"
+— {author_name_ko} ({author_name_en})
+
+주제: {topics}
+태그: {tags}
+저자 소개: {author_bio_ko}
+""",
+    metadata={
+        "blog_id": "inspireme",
+        "type": "quote",
+        "quote_id": "uuid-xxx",
+        "author": "알베르트 아인슈타인",
+        "author_slug": "albert-einstein",
+        "topics": ["인생", "지혜"],
+        "tags": ["motivation", "wisdom"],
+        "language": "ko",
+        "url": "https://inspireme.advenoh.pe.kr/quotes/uuid-xxx",
+    }
+)
+```
+
+#### Document 구조 — 저자
+
+```python
+Document(
+    page_content="""
+{author_name_ko} ({author_name_en})
+국적: {nationality}
+출생: {birth_year}, 사망: {death_year}
+
+소개 (한국어): {bio_ko}
+소개 (English): {bio_en}
+""",
+    metadata={
+        "blog_id": "inspireme",
+        "type": "author",
+        "author_id": "uuid-xxx",
+        "author_slug": "albert-einstein",
+        "nationality": "DE",
+        "url": "https://inspireme.advenoh.pe.kr/authors/albert-einstein",
+    }
+)
+```
+
+### 4.2 다국어 처리
+
+- `page_content`에 ko/en 번역을 **모두 포함**하여 어떤 언어로 질문해도 검색 가능
+- 사용자 질문 언어에 따라 답변 언어를 결정하는 것은 LLM 프롬프트로 처리
+
+### 4.3 인덱싱 파이프라인
+
+```mermaid
+flowchart LR
+    A["POST /index/inspireme"] --> B["MySQL 접속"]
+    B --> C["quotes + quote_translations JOIN"]
+    C --> D["authors + author_translations JOIN"]
+    D --> E["Document 객체 변환"]
+    E --> F["ChromaDB 'inspireme' collection에 저장"]
+```
+
+### 4.4 DB 쿼리
+
+```sql
+-- 명언 + 번역 조회
+SELECT q.id, q.author, q.author_id, q.topics, q.tags,
+       qt_ko.content AS content_ko, qt_en.content AS content_en
+FROM quotes q
+LEFT JOIN quote_translations qt_ko ON q.id = qt_ko.quote_id AND qt_ko.lang = 'ko'
+LEFT JOIN quote_translations qt_en ON q.id = qt_en.quote_id AND qt_en.lang = 'en'
+
+-- 저자 + 번역 조회
+SELECT a.id, a.slug, a.birth_year, a.death_year, a.nationality,
+       at_ko.name AS name_ko, at_ko.bio AS bio_ko,
+       at_en.name AS name_en, at_en.bio AS bio_en
+FROM authors a
+LEFT JOIN author_translations at_ko ON a.id = at_ko.author_id AND at_ko.lang = 'ko'
+LEFT JOIN author_translations at_en ON a.id = at_en.author_id AND at_en.lang = 'en'
+```
+
+---
+
+## 5. ai-chatbot 백엔드 변경사항
+
+### 5.1 새로운 Document Loader
+
+```
+backend/app/rag/
+├── document_loader.py          # 기존: Markdown 파일 로드
+└── inspireme_loader.py         # 신규: MySQL DB에서 명언/저자 로드
+```
+
+```python
+# backend/app/rag/inspireme_loader.py
+
+async def load_inspireme_documents(db_url: str) -> list[Document]:
+    """MySQL에서 명언/저자 데이터를 로드하여 Document 리스트로 반환"""
+    quotes_docs = await _load_quotes(db_url)
+    author_docs = await _load_authors(db_url)
+    return quotes_docs + author_docs
+```
+
+### 5.2 config.py 변경
+
+```python
+# blog_collections에 inspireme 추가
+blog_collections = {
+    "blog-v2": "IT 블로그",
+    "investment": "투자 블로그",
+    "inspireme": "명언",          # 신규
+}
+
+# inspireme DB 접속 정보 (환경변수)
+inspireme_mysql_host: str = "localhost"
+inspireme_mysql_port: int = 3306
+inspireme_mysql_database: str = "inspireme"
+inspireme_mysql_user: str = "inspireme"
+inspireme_mysql_password: str = ""
+```
+
+### 5.3 인덱싱 엔드포인트 확장
+
+```python
+# backend/app/api/routes.py — /index/{blog_id} 분기 추가
+@router.post("/index/{blog_id}")
+async def index_documents(blog_id: str, ...):
+    if blog_id == "inspireme":
+        documents = await load_inspireme_documents(db_url)
+        # 청킹 없이 바로 인덱싱 (명언은 이미 짧음)
+        count = vector_store_manager.index_documents(blog_id, documents)
+    else:
+        # 기존: Markdown 파일 로드 + 청킹
+        documents = load_blog_documents(contents_dir)
+        chunks = chunk_documents(documents)
+        count = vector_store_manager.index_documents(blog_id, chunks)
+```
+
+### 5.4 inspireme 전용 프롬프트
+
+```python
+# backend/app/prompts/templates.py
+
+INSPIREME_SYSTEM_PROMPT = """당신은 명언 추천 전문 AI 어시스턴트입니다.
+사용자의 질문에 맞는 명언을 추천하고, 저자 정보를 안내합니다.
+
+규칙:
+- 검색된 명언을 인용할 때는 원문을 그대로 사용하세요
+- 저자 이름과 출처를 반드시 함께 제공하세요
+- 사용자의 감정이나 상황에 공감하며 적절한 명언을 추천하세요
+- 검색 결과에 없는 명언을 지어내지 마세요
+- 한국어로 답변하되, 영어 원문이 있으면 함께 제공하세요
+"""
+```
+
+### 5.5 체인 선택 로직
+
+```python
+# backend/app/rag/chain.py — blog_id에 따라 프롬프트 분기
+def create_rag_chain(retriever, blog_id: str):
+    if blog_id == "inspireme":
+        system_prompt = INSPIREME_SYSTEM_PROMPT
+    else:
+        system_prompt = DEFAULT_SYSTEM_PROMPT
+    # 이하 기존 체인 생성 로직 동일
+```
+
+---
+
+## 6. inspireme 프론트엔드 챗봇 UI 통합
+
+### 6.1 통합 방식
+
+inspireme 프론트엔드 우측 하단에 **플로팅 챗봇 버튼**을 추가한다. 클릭하면 챗봇 패널이 슬라이드업되어 나타난다.
+
+### 6.2 동작 흐름
+
+```mermaid
+flowchart LR
+    A["💬 플로팅 버튼 클릭"] --> B["챗봇 패널 열림"]
+    B --> C["사용자 질문 입력"]
+    C --> D["POST ai-chatbot.advenoh.pe.kr/chat"]
+    D --> E["답변 + 출처 표시"]
+    E --> F["출처 클릭 → 명언 상세 페이지 이동"]
+```
+
+### 6.3 컴포넌트 구조
+
+```
+inspireme.advenoh.pe.kr/frontend/
+└── components/
+    └── chatbot/
+        ├── ChatbotButton.tsx       # 우측 하단 플로팅 버튼
+        ├── ChatbotPanel.tsx        # 슬라이드업 챗봇 패널 (ChatWindow 역할)
+        ├── ChatMessageList.tsx     # 메시지 목록
+        └── ChatInput.tsx           # 입력 폼
+```
+
+### 6.4 API 연동
+
+```typescript
+// inspireme frontend에서 ai-chatbot 백엔드 직접 호출
+const AI_CHATBOT_API = process.env.NEXT_PUBLIC_AI_CHATBOT_API_URL
+  || "https://ai-chatbot.advenoh.pe.kr";
+
+export async function sendChat(question: string, chatHistory: ChatMessage[]) {
+  const response = await fetch(`${AI_CHATBOT_API}/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      blog_id: "inspireme",
+      question,
+      chat_history: chatHistory,
+    }),
+  });
+  return response.json();
+}
+```
+
+### 6.5 UI 명세
+
+| 요소 | 설명 |
+|------|------|
+| 플로팅 버튼 | 우측 하단 고정, `MessageCircle` 아이콘 (lucide-react) |
+| 챗봇 패널 | 우측 하단 400×500px, 라운드 코너, 그림자 |
+| 헤더 | "명언 AI 도우미" 타이틀 + 닫기 버튼 |
+| 메시지 영역 | ScrollArea, 사용자(우측/파란)/AI(좌측/회색) |
+| 출처 링크 | 명언 상세 페이지(`/quotes/{id}`)로 이동 |
+| 입력 폼 | Input + Send 버튼, 엔터 키 제출 |
+| 피드백 | 👍👎 버튼 (ai-chatbot의 기존 `/feedback` API 활용) |
+| 추천 질문 | 초기 상태에서 예시 질문 표시 (선택 사항) |
+
+### 6.6 추천 질문 예시
+
+```
+- "오늘 힘이 되는 명언 추천해줘"
+- "아인슈타인의 명언이 있나요?"
+- "인생에 대한 명언을 찾고 있어요"
+- "동기부여가 되는 짧은 명언 알려줘"
+```
+
+---
+
+## 7. 인덱싱 전략
+
+### 7.1 트리거 방식
+
+| 방식 | 설명 | 적용 |
+|------|------|------|
+| API 호출 | `POST /index/inspireme` + Bearer token | 수동 재인덱싱 |
+| inspireme 배포 시 | inspireme 백엔드 배포 후 webhook으로 인덱싱 트리거 | 자동 (GitHub Actions) |
+| 명언 CRUD 시 | inspireme 백엔드에서 명언 생성/수정/삭제 후 ai-chatbot API 호출 | 실시간 반영 (향후) |
+
+### 7.2 GitHub Actions 워크플로우
+
+```yaml
+# inspireme.advenoh.pe.kr/.github/workflows/reindex-chatbot.yml
+name: Reindex Chatbot
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/db/changes/**'  # DB 마이그레이션 변경 시
+
+jobs:
+  reindex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger reindex
+        run: |
+          curl -X POST "https://ai-chatbot.advenoh.pe.kr/index/inspireme" \
+            -H "Authorization: Bearer ${{ secrets.RAG_INDEX_TOKEN }}"
+```
+
+---
+
+## 8. 환경변수 추가
+
+### 8.1 ai-chatbot 백엔드 (`backend/.env`)
+
+```bash
+# inspireme DB 접속 (인덱싱 시 사용)
+INSPIREME_MYSQL_HOST=mysql-headless.app.svc.cluster.local
+INSPIREME_MYSQL_PORT=3306
+INSPIREME_MYSQL_DATABASE=inspireme
+INSPIREME_MYSQL_USER=inspireme
+INSPIREME_MYSQL_PASSWORD=<password>
+```
+
+### 8.2 inspireme 프론트엔드
+
+```bash
+# ai-chatbot API URL
+NEXT_PUBLIC_AI_CHATBOT_API_URL=https://ai-chatbot.advenoh.pe.kr
+```
+
+---
+
+## 9. 구현 순서 (마일스톤)
+
+| 단계 | 작업 | 산출물 |
+|------|------|--------|
+| M1 | `inspireme_loader.py` — DB → Document 변환 로직 + 테스트 | Document Loader |
+| M2 | `/index/inspireme` 엔드포인트 확장 + config 추가 | 인덱싱 API |
+| M3 | inspireme 전용 프롬프트 + 체인 분기 | RAG 체인 |
+| M4 | inspireme 프론트엔드 챗봇 UI (플로팅 버튼 + 패널) | 챗봇 UI |
+| M5 | 피드백 연동 + 추천 질문 + GitHub Actions 자동 인덱싱 | 완성 |
+
+---
+
+## 10. 논의가 필요한 결정사항
+
+### 10.1 임베딩 전략
+
+명언은 1-2문장으로 매우 짧다. 현재 `text-embedding-3-small` 모델이 짧은 텍스트에서도 충분한 의미 검색 성능을 내는지 확인이 필요하다.
+
+- **옵션 A**: 명언 텍스트만 임베딩 (현재 `page_content` 기준)
+- **옵션 B**: 명언 + 저자 + 주제 + 태그를 합쳐서 임베딩 (컨텍스트 강화)
+- **권장**: 옵션 B — 짧은 텍스트의 의미를 보강하기 위해 메타데이터를 `page_content`에 포함
+
+### 10.2 검색 전략
+
+- **Semantic Search만**: 현재 기본값, "힘이 되는 명언" 같은 의미 기반 질문에 적합
+- **Hybrid Search (BM25 + Semantic)**: 저자 이름, 특정 키워드 검색에 유리
+- **권장**: Hybrid Search — 명언 검색은 저자 이름/키워드 매칭이 빈번
+
+### 10.3 인덱싱 단위
+
+- **옵션 A**: 명언 Document + 저자 Document 분리 → 검색 결과 다양성 확보
+- **옵션 B**: 명언 Document에 저자 정보 포함 → 단일 검색으로 충분한 컨텍스트
+- **권장**: 옵션 A — "아인슈타인에 대해 알려줘" 같은 저자 중심 질문도 처리 가능
+
+### 10.4 top_k 값
+
+- 기존 blog-v2: `top_k=5` (긴 블로그 글 5개)
+- inspireme: 명언이 짧으므로 더 많은 Document를 검색해도 컨텍스트 윈도우 여유
+- **권장**: `top_k=10` 이상으로 설정하여 다양한 명언 추천
+
+### 10.5 Cross-Origin 통신
+
+inspireme 프론트엔드에서 ai-chatbot 백엔드를 직접 호출하면 CORS 설정이 필요하다.
+
+- **옵션 A**: ai-chatbot 백엔드 CORS에 `inspireme.advenoh.pe.kr` 허용
+- **옵션 B**: inspireme 백엔드에서 프록시 (Next.js rewrites)
+- **권장**: 옵션 B — Next.js rewrites로 `/api/chatbot/*` → `ai-chatbot.advenoh.pe.kr/*` 프록시하면 CORS 이슈 없음
+
+### 10.6 인덱싱 시 DB 접속
+
+ai-chatbot 백엔드가 inspireme MySQL DB에 직접 접속해야 한다.
+
+- K8s 환경: 같은 클러스터 내 `mysql-headless.app.svc.cluster.local` 접속 가능
+- 로컬 개발: inspireme의 Docker MySQL 컨테이너에 접속 (포트 포워딩)
+- **보안**: 읽기 전용 DB 계정 사용 권장
+
+---
+
+## 11. 테스트
+
+### 11.1 Backend 테스트
+
+**`tests/test_inspireme_loader.py`**:
+- DB → Document 변환 정확성 (명언 내용, 저자 정보, 메타데이터)
+- 다국어 번역 포함 여부
+- 빈 번역 처리 (fallback)
+- URL 생성 정확성
+
+**`tests/test_api.py`** (확장):
+- `POST /index/inspireme` → 인덱싱 성공 + Document 수 반환
+- `POST /chat { blog_id: "inspireme" }` → 명언 검색 + 답변 생성
+- 잘못된 blog_id → 400 에러
+
+### 11.2 Frontend 테스트
+
+- 플로팅 버튼 클릭 → 패널 열림/닫힘
+- 질문 입력 → API 호출 → 답변 표시
+- 출처 클릭 → 명언 상세 페이지 이동
+- 피드백 버튼 동작

--- a/docs/start/3_inspire_bot_todo.md
+++ b/docs/start/3_inspire_bot_todo.md
@@ -1,0 +1,154 @@
+# InspireMe 챗봇 - TODO 체크리스트
+
+## M1: Document Loader — DB → Document 변환 로직
+
+### Backend - inspireme_loader.py
+
+- [ ] `app/rag/inspireme_loader.py` — 신규 파일 생성
+  - [ ] `QUOTES_QUERY` — quotes + quote_translations + authors + author_translations JOIN 쿼리
+  - [ ] `AUTHORS_QUERY` — authors + author_translations JOIN 쿼리
+  - [ ] `_build_quote_document()` — 명언 DB 레코드 → Document 변환 (ko/en 번역 포함)
+  - [ ] `_build_author_document()` — 저자 DB 레코드 → Document 변환 (ko/en 번역 포함)
+  - [ ] `load_inspireme_documents()` — DB 연결 → Document 리스트 반환
+
+### Backend - 테스트
+
+- [ ] `tests/test_inspireme_loader.py` — 신규 테스트 파일
+  - [ ] `_build_quote_document()` 변환 정확성 (page_content, metadata)
+  - [ ] `_build_author_document()` 변환 정확성
+  - [ ] 다국어 번역 포함 여부 (ko + en 모두 page_content에 포함)
+  - [ ] 빈 번역 처리 (content_ko 또는 content_en이 None인 경우 fallback)
+  - [ ] URL 생성 정확성 (`/quotes/{id}`, `/authors/{slug}`)
+
+---
+
+## M2: 인덱싱 API 확장 + Config 추가
+
+### Backend - config.py
+
+- [ ] `app/config.py` — `blog_collections`에 `"inspireme": "명언"` 추가
+- [ ] `app/config.py` — inspireme DB 접속 설정 추가
+  - [ ] `inspireme_mysql_host`, `inspireme_mysql_port`, `inspireme_mysql_database`
+  - [ ] `inspireme_mysql_user`, `inspireme_mysql_password`
+  - [ ] `inspireme_database_url` 프로퍼티 추가
+
+### Backend - routes.py
+
+- [ ] `app/api/routes.py` — `/index/{blog_id}` 엔드포인트에 inspireme 분기 추가
+  - [ ] `blog_id == "inspireme"`인 경우 `load_inspireme_documents()` 호출
+  - [ ] 청킹 없이 바로 `index_documents()` 호출
+
+### Backend - 환경변수
+
+- [ ] `backend/.env.example` — INSPIREME_MYSQL_* 환경변수 추가
+- [ ] `backend/.env` — 로컬 개발용 inspireme DB 접속 정보 설정
+
+### Backend - 테스트
+
+- [ ] `tests/test_api.py` — `POST /index/inspireme` 정상 인덱싱 확인 (mock DB)
+- [ ] 로컬 환경에서 실제 inspireme DB 연결 → 인덱싱 → ChromaDB 저장 확인
+
+---
+
+## M3: inspireme 전용 프롬프트 + 체인 분기
+
+### Backend - 프롬프트
+
+- [ ] `app/prompts/templates.py` — `INSPIREME_SYSTEM_PROMPT` 추가
+  - [ ] 명언 추천 전문 AI 어시스턴트 역할 지정
+  - [ ] 원문 인용, 저자 명시, 공감 스타일 규칙
+  - [ ] 다국어 답변 (한국어 + 영어 원문 병기)
+
+### Backend - 체인 분기
+
+- [ ] `app/rag/chain.py` — `create_rag_chain()`에 `blog_id` 파라미터 추가
+  - [ ] `blog_id == "inspireme"`이면 `INSPIREME_SYSTEM_PROMPT` 사용
+  - [ ] 그 외에는 기존 `SYSTEM_PROMPT` 사용
+- [ ] `app/api/routes.py` — `/chat` 엔드포인트에서 `create_rag_chain()` 호출 시 `blog_id` 전달
+
+### Backend - 테스트
+
+- [ ] `POST /chat { blog_id: "inspireme" }` → 명언 검색 + 답변 생성 확인
+- [ ] 기존 blog-v2, investment chat이 정상 동작하는지 회귀 테스트
+
+---
+
+## M4: inspireme 프론트엔드 챗봇 UI
+
+### Frontend - API 클라이언트
+
+- [ ] `lib/chatbot-api.ts` — 신규 파일 생성
+  - [ ] `ChatMessage`, `Source`, `ChatResponse`, `FeedbackRequest` 인터페이스
+  - [ ] `sendChat()` — POST /chatbot-api/chat 호출
+  - [ ] `sendFeedback()` — POST /chatbot-api/feedback 호출
+
+### Frontend - Next.js 리라이트
+
+- [ ] `next.config.ts` — `/chatbot-api/:path*` → ai-chatbot 백엔드 리라이트 추가
+  - [ ] 환경변수: `CHATBOT_API_URL` (기본값: `http://localhost:8080`)
+
+### Frontend - 챗봇 컴포넌트
+
+- [ ] `components/chatbot/ChatbotButton.tsx` — 플로팅 버튼
+  - [ ] 우측 하단 고정 (`fixed bottom-6 right-6 z-50`)
+  - [ ] `MessageCircle` 아이콘 (lucide-react)
+  - [ ] 클릭 시 ChatbotPanel 토글 (open/close 상태)
+- [ ] `components/chatbot/ChatbotPanel.tsx` — 챗봇 패널 메인 컨테이너
+  - [ ] 우측 하단 400×500px (`fixed bottom-20 right-6`)
+  - [ ] 헤더: "명언 AI 도우미" 타이틀 + X 닫기 버튼
+  - [ ] messages 상태 관리 (user + ai 메시지 배열)
+  - [ ] isLoading, error 상태 관리
+  - [ ] handleSend: chat_history 구성 + sendChat 호출
+  - [ ] ChatMessageList + ChatInput 합성
+- [ ] `components/chatbot/ChatMessageList.tsx` — 메시지 목록
+  - [ ] ScrollArea + 자동 하단 스크롤 (useRef + scrollIntoView)
+  - [ ] 사용자 메시지: 우측 정렬, 파란색 배경
+  - [ ] AI 메시지: 좌측 정렬, 회색 배경
+  - [ ] 출처 링크 표시 (title + url)
+  - [ ] 👍👎 피드백 버튼 (AI 메시지 하단)
+  - [ ] 피드백 전송 후 버튼 비활성화 + 확인 표시
+  - [ ] 로딩 상태: "답변을 생성하고 있습니다..." 펄스 애니메이션
+  - [ ] 초기 상태: 추천 질문 예시 표시
+- [ ] `components/chatbot/ChatInput.tsx` — 입력 폼
+  - [ ] Input + Send 버튼
+  - [ ] 엔터 키 제출 지원
+  - [ ] 로딩 중 비활성화
+  - [ ] placeholder: "명언에 대해 질문해 보세요..."
+
+### Frontend - 레이아웃 통합
+
+- [ ] `app/layout.tsx` — ChatbotButton 컴포넌트 추가 (전체 페이지에 표시)
+
+### 테스트 (MCP Playwright)
+
+- [ ] inspireme 사이트에서 플로팅 버튼 렌더링 확인
+- [ ] 버튼 클릭 → 챗봇 패널 열림/닫힘 확인
+- [ ] 질문 입력 → API 호출 → 답변 표시 확인
+- [ ] 출처 링크 클릭 → 명언 상세 페이지 이동 확인
+- [ ] 👍👎 피드백 버튼 동작 확인
+
+---
+
+## M5: 피드백 연동 + GitHub Actions + 마무리
+
+### Charts 변경
+
+- [ ] `charts/ai-chatbot-be/values.yaml` — inspireme MySQL 환경변수 추가
+- [ ] `charts/ai-chatbot-be/templates/configmap.yaml` — INSPIREME_MYSQL_HOST/PORT/DATABASE 추가
+- [ ] `charts/ai-chatbot-be/templates/secret.yaml` — INSPIREME_MYSQL_USER/PASSWORD 추가
+- [ ] `charts/inspireme-fe/values.yaml` — CHATBOT_API_URL 환경변수 추가
+
+### GitHub Actions (선택)
+
+- [ ] `inspireme.advenoh.pe.kr/.github/workflows/reindex-chatbot.yml` — 재인덱싱 워크플로우
+  - [ ] 트리거: push to main (backend/db/changes/** 변경 시)
+  - [ ] 동작: `curl -X POST .../index/inspireme` + Bearer token
+
+### 배포
+
+- [ ] ai-chatbot Backend Docker 이미지 빌드 및 푸시
+- [ ] inspireme Frontend Docker 이미지 빌드 및 푸시
+- [ ] Charts 버전 업데이트 (ai-chatbot-be, inspireme-fe values.yaml)
+- [ ] PR 생성 → main merge → release 브랜치 푸시
+- [ ] ArgoCD sync 확인
+- [ ] 운영 환경에서 inspireme 챗봇 동작 확인


### PR DESCRIPTION
## Summary
- InspireMe 사이트에 AI 챗봇을 추가하기 위한 PRD, 구현 계획서, TODO 체크리스트 작성
- 핵심 도전과제 정리: MySQL DB 기반 데이터 소스, 짧은 텍스트 청킹 전략, 다국어 지원
- ai-chatbot 백엔드 변경사항: inspireme_loader, 전용 프롬프트, 체인 분기
- inspireme 프론트엔드 챗봇 UI 통합: 플로팅 버튼 + 채팅 패널
- M1~M5 마일스톤별 구현 순서 및 체크리스트

## 생성된 문서
- `docs/start/3_inspire_bot_prd.md` — 요구사항 정의
- `docs/start/3_inspire_bot_implementation.md` — 구현 계획서
- `docs/start/3_inspire_bot_todo.md` — TODO 체크리스트

## Test plan
- [x] PRD 문서가 기존 PRD 형식과 일치하는지 확인 (참고: `docs/done/8_chatbot_monitoring_prd.md`)
- [x] 모든 핵심 논의사항이 포함되었는지 확인
- [x] 구현 계획서에 실제 코드 구조와 일치하는 파일 경로 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)