### PR TITLE
feat: ai-chatbot 프론트엔드에 InspireMe 블로그 옵션 추가

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -25,11 +25,13 @@ import { useBlog } from "@/lib/BlogContext";
 const BLOG_OPTIONS = [
   { value: "blog-v2", label: "IT Blog" },
   { value: "investment", label: "Investment Blog" },
+  { value: "inspireme", label: "InspireMe" },
 ];
 
 const EXTERNAL_LINKS = [
   { label: "IT Blog", url: "https://blog-v2.advenoh.pe.kr" },
   { label: "Investment Blog", url: "https://investment.advenoh.pe.kr" },
+  { label: "InspireMe", url: "https://inspire-me.advenoh.pe.kr" },
 ];
 
 export function Header() {

--- a/frontend/src/components/admin/CollectionInfo.tsx
+++ b/frontend/src/components/admin/CollectionInfo.tsx
@@ -7,6 +7,7 @@ export function CollectionInfo({ blogId, totalQueries }: CollectionInfoProps) {
   const collections = [
     { id: "blog-v2", label: "IT Blog" },
     { id: "investment", label: "Investment Blog" },
+    { id: "inspireme", label: "InspireMe" },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- Header 블로그 선택 드롭다운에 InspireMe 옵션 추가
- 외부 링크 메뉴에 InspireMe 사이트 링크 추가
- Admin CollectionInfo에 InspireMe 컬렉션 표시 추가

## Test plan
- [ ] ai-chatbot 사이트에서 블로그 드롭다운에 InspireMe 표시 확인
- [ ] InspireMe 선택 후 챗봇 질문/응답 동작 확인
- [ ] Admin 페이지 인덱싱 현황에 InspireMe 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)