### PR TITLE
chore: 사이트 제목을 Chatbot Playground로 변경

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -15,7 +15,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Blog Q&A Chatbot",
+  title: "Chatbot Playground",
   description: "RAG 기반 블로그 Q&A 챗봇",
 };
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -43,7 +43,7 @@ export function Header() {
     <header className="flex h-14 items-center justify-between border-b px-4">
       <div className="flex items-center gap-3">
         <Link href="/" className="text-lg font-semibold hover:opacity-80">
-          Blog Q&A Chatbot
+          Chatbot Playground
         </Link>
         {isChat && (
           <Select value={blogId} onValueChange={setBlogId}>


### PR DESCRIPTION
## Summary
- Header 타이틀: Blog Q&A Chatbot → Chatbot Playground
- 브라우저 탭 메타데이터 title 동일 변경

## Test plan
- [ ] 헤더에 Chatbot Playground 표시 확인
- [ ] 브라우저 탭 제목 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)